### PR TITLE
added-semantic-similarity-metric

### DIFF
--- a/flotorch_core/evaluator/metrics/metrics_keys.py
+++ b/flotorch_core/evaluator/metrics/metrics_keys.py
@@ -6,3 +6,4 @@ class MetricKey(str, Enum):
     ASPECT_CRITIC_MALICIOUSNESS = "aspect_critic_maliciousness"
     FAITHFULNESS = "faithfulness"
     ANSWER_RELEVANCE = "answer_relevance"
+    ANSWER_SIMILARITY="semantic_similarity"

--- a/flotorch_core/evaluator/metrics/metrics_keys.py
+++ b/flotorch_core/evaluator/metrics/metrics_keys.py
@@ -6,4 +6,4 @@ class MetricKey(str, Enum):
     ASPECT_CRITIC_MALICIOUSNESS = "aspect_critic_maliciousness"
     FAITHFULNESS = "faithfulness"
     ANSWER_RELEVANCE = "answer_relevance"
-    ANSWER_SIMILARITY="semantic_similarity"
+    SEMANTIC_SIMILARITY="semantic_similarity"

--- a/flotorch_core/evaluator/metrics/ragas_metrics/ragas_metrics.py
+++ b/flotorch_core/evaluator/metrics/ragas_metrics/ragas_metrics.py
@@ -33,11 +33,11 @@ class RagasEvaluationMetrics(BaseEvaluationMetric):
         },
         MetricKey.ANSWER_RELEVANCE: {
             "class": ResponseRelevancy,
-            "requires": ["llm","embeddings"]
+            "requires": ["llm", "embeddings"]
         },
         MetricKey.SEMANTIC_SIMILARITY: {
-        "class": SemanticSimilarity,
-        "requires": [ "embeddings"]
+            "class": SemanticSimilarity,
+            "requires": ["embeddings"]
         }
     }
 

--- a/flotorch_core/evaluator/metrics/ragas_metrics/ragas_metrics.py
+++ b/flotorch_core/evaluator/metrics/ragas_metrics/ragas_metrics.py
@@ -5,6 +5,7 @@ from ragas.metrics import (
     ResponseRelevancy,
     LLMContextPrecisionWithReference,
     AspectCritic,
+    SemanticSimilarity
 )
 
 from flotorch_core.evaluator.metrics.base_metrics import BaseEvaluationMetric
@@ -32,8 +33,12 @@ class RagasEvaluationMetrics(BaseEvaluationMetric):
         },
         MetricKey.ANSWER_RELEVANCE: {
             "class": ResponseRelevancy,
-            "requires": ["llm", "embeddings"]
+            "requires": ["embeddings"]
         },
+        MetricKey.ANSWER_SIMILARITY: {
+        "class": SemanticSimilarity,
+        "requires": [ "embeddings"]
+        }
     }
 
     """

--- a/flotorch_core/evaluator/metrics/ragas_metrics/ragas_metrics.py
+++ b/flotorch_core/evaluator/metrics/ragas_metrics/ragas_metrics.py
@@ -33,9 +33,9 @@ class RagasEvaluationMetrics(BaseEvaluationMetric):
         },
         MetricKey.ANSWER_RELEVANCE: {
             "class": ResponseRelevancy,
-            "requires": ["embeddings"]
+            "requires": ["llm","embeddings"]
         },
-        MetricKey.ANSWER_SIMILARITY: {
+        MetricKey.SEMANTIC_SIMILARITY: {
         "class": SemanticSimilarity,
         "requires": [ "embeddings"]
         }


### PR DESCRIPTION
This PR adds a new metric called semantic_similarity to evaluate how semantically similar the generated answer is to the correct answer. 